### PR TITLE
Zipcode fix + format forecast time

### DIFF
--- a/routes/weather.js
+++ b/routes/weather.js
@@ -190,17 +190,17 @@ function partition(array, n) {
     {
       "Temperature": 57.52,
       "Weather Description": "light rain",
-      "Time": "2:16 PM"
+      "Time": "2:00 PM"
     },
     {
       "Temperature": 57.67,
       "Weather Description": "scattered clouds",
-      "Time": "3:16 PM"
+      "Time": "3:00 PM"
     },
     {
       "Temperature": 57.02,
       "Weather Description": "broken clouds",
-      "Time": "4:16 PM"
+      "Time": "4:00 PM"
     }
   ]
 }

--- a/utilities/locationUtils.js
+++ b/utilities/locationUtils.js
@@ -46,7 +46,7 @@ function incrementDateHour(date, nHour) {
     } else if (hours === 0) {
         hours = 12;
     }
-    return hours + ":" + d.getMinutes() + ' ' + ampm
+    return hours + ':00' + ampm
 }
 
 module.exports = {

--- a/utilities/locationUtils.js
+++ b/utilities/locationUtils.js
@@ -21,7 +21,10 @@ rl.on('line', (line) => {
  * @param {String} zipcode The zipcode to convert to longitude and latitude
  */
 let getLongLatFromZipcode = (zipcode) => {
-    return map[zipcode]
+    let latlong = map[zipcode]
+    latlong[0] = latlong[0].replace(/\s+/g, '')
+    latlong[1] = latlong[1].replace(/\s+/g, '')
+    return latlong
 }
 
 /** 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This pull request fixes the problems for zipcode and also reformats the time returned back to the app. This fixes the zip code issue by removing the white spaces from latitude and longitude. The problem was that there was an extra space in front of the longitude for some zipcodes. The fix was just to remove them. The time now will only return back the hour and emit the minutes. 


Fixes # (issue)
[#172](https://github.com/gtullio12/Team-1-TCSS-450/issues/172)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested using Postman 

