### PR TITLE
Endpoint creation for user verification

### DIFF
--- a/routes/verification.js
+++ b/routes/verification.js
@@ -90,4 +90,62 @@ router.put('/change-password', (request, response) => {
     }
 })
 
+/**
+ * @api {get} /check-verify/:email Check if a user has been verified
+ * @apiName VerifyUser
+ * @apiGroup Auth
+ * 
+ * @apiHeader {String} email "email" 
+ * 
+ * @apiSuccess {json} 
+ * 
+ *  * @apiSuccessExample {json} Success-Response:
+ *     HTTP/1.1 201 OK
+ *     {
+ *       "verify": true
+ *     }
+ * 
+ * @apiError (400: Missing Authorization Header) {String} message "Missing user"
+ * 
+ * @apiError (400: Malformed Authorization Header) {String} message "Malformed Authorization Header"
+ * 
+ * @apiError (404: User Not Found) {String} message "User not found"
+ * 
+ */
+router.get('/check-verify/:email', (request, response, next) => {
+    const email = request.params.email
+
+    if (isValidEmail(email)) {
+        let query = 'SELECT verification FROM MEMBERS WHERE email=$1'
+        let values = [email]
+        pool.query(query, values)
+            .then(result => {
+                if (result.rowCount == 0) {
+                    response.status(404).send({
+                        message: 'User not found'
+                    })
+                } else {
+                    let verifyResult = result.rows[0]
+                    if (verifyResult.verification == 0) {
+                        response.status(201).send({
+                            verify: "false"
+                        })
+                    } else {
+                        response.status(201).send({
+                            verify: "true"
+                        })
+                    }
+                }
+            })
+            .catch((error) => {
+                console.log(error)
+                response.status(400).send()
+            })
+    } else {
+        response.status(400).send({
+            message: "Invalid Email!"
+        })
+    }
+})
+
 module.exports = router;

--- a/routes/verification.js
+++ b/routes/verification.js
@@ -92,7 +92,7 @@ router.put('/change-password', (request, response) => {
 
 /**
  * @api {get} /check-verify/:email Check if a user has been verified
- * @apiName VerifyUser
+ * @apiName CheckVerify 
  * @apiGroup Auth
  * 
  * @apiHeader {String} email "email" 
@@ -136,6 +136,42 @@ router.get('/check-verify/:email', (request, response, next) => {
                         })
                     }
                 }
+            })
+            .catch((error) => {
+                console.log(error)
+                response.status(400).send()
+            })
+    } else {
+        response.status(400).send({
+            message: "Invalid Email!"
+        })
+    }
+})
+
+/**
+ * @api {get} /verify-user/:email Verify user
+ * @apiName VerifyUser 
+ * @apiGroup Auth
+ * 
+ * @apiHeader {String} email "email" 
+ * 
+ * @apiSuccess (200: Success)
+ * 
+ * @apiError (400: Missing Authorization Header) {String} message "Missing user"
+ * 
+ * @apiError (400: Malformed Authorization Header) {String} message "Malformed Authorization Header"
+ * 
+ * @apiError (404: User Not Found) {String} message "User not found"
+ * 
+ */
+router.post('/verify-user/:email', (request, response) => {
+    const email = request.params.email
+    if (isValidEmail(email)) {
+        let query = 'UPDATE MEMBERS SET verification=1 WHERE email=$1'
+        let values = [1]
+        pool.query(query, values)
+            .then(result => {
+                response.status(200).send()
             })
             .catch((error) => {
                 console.log(error)


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This pull request creates two endpoints. One for checking to see if the user is verified, the other is a POST request that sets the user as a verified user. When the client checks if the user is verified and uses the endpoint then the server will return a JSON object with only one field, "verify" which will only be true or false. When the client verifies the user than if it was successful than nothing is returned back, just a 200 response. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I took some screenshots from postman as an example. 

[Check if user is verified](https://ibb.co/vJZjyxB)
[Verify User(Will only return 200 response)](https://ibb.co/tP2Zx0w)

